### PR TITLE
Enable all USB-Ports

### DIFF
--- a/EFI/oc/Kexts/USBMap.kext/Contents/Info.plist
+++ b/EFI/oc/Kexts/USBMap.kext/Contents/Info.plist
@@ -22,7 +22,7 @@
 	<string>1.0</string>
 	<key>IOKitPersonalities</key>
 	<dict>
-		<key>MacBookPro14,-XHC</key>
+		<key>MacBookPro14,1-XHC</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
 			<string>com.apple.driver.AppleUSBHostMergeProperties</string>
@@ -44,14 +44,14 @@
 				<true/>
 				<key>port-count</key>
 				<data>
-				DQAAAA==
+				EgAAAA==
 				</data>
 				<key>ports</key>
 				<dict>
 					<key>HS01</key>
 					<dict>
 						<key>UsbConnector</key>
-						<integer>0</integer>
+						<integer>3</integer>
 						<key>port</key>
 						<data>
 						AQAAAA==
@@ -60,7 +60,7 @@
 					<key>HS02</key>
 					<dict>
 						<key>UsbConnector</key>
-						<integer>0</integer>
+						<integer>3</integer>
 						<key>port</key>
 						<data>
 						AgAAAA==
@@ -68,12 +68,12 @@
 					</dict>
 					<key>HS03</key>
 					<dict>
-						<key>UsbConnector</key>
-						<integer>0</integer>
-						<key>port</key>
+						<key>#port</key>
 						<data>
 						AwAAAA==
 						</data>
+						<key>UsbConnector</key>
+						<integer>3</integer>
 					</dict>
 					<key>HS04</key>
 					<dict>
@@ -86,17 +86,17 @@
 					</dict>
 					<key>HS05</key>
 					<dict>
-						<key>UsbConnector</key>
-						<integer>255</integer>
-						<key>port</key>
+						<key>#port</key>
 						<data>
 						BQAAAA==
 						</data>
+						<key>UsbConnector</key>
+						<integer>3</integer>
 					</dict>
 					<key>HS06</key>
 					<dict>
 						<key>UsbConnector</key>
-						<integer>255</integer>
+						<integer>3</integer>
 						<key>port</key>
 						<data>
 						BgAAAA==
@@ -104,17 +104,17 @@
 					</dict>
 					<key>HS07</key>
 					<dict>
-						<key>#port</key>
+						<key>UsbConnector</key>
+						<integer>3</integer>
+						<key>port</key>
 						<data>
 						BwAAAA==
 						</data>
-						<key>UsbConnector</key>
-						<integer>3</integer>
 					</dict>
 					<key>HS08</key>
 					<dict>
 						<key>UsbConnector</key>
-						<integer>255</integer>
+						<integer>3</integer>
 						<key>port</key>
 						<data>
 						CAAAAA==
@@ -176,12 +176,12 @@
 					</dict>
 					<key>SS03</key>
 					<dict>
-						<key>#port</key>
+						<key>UsbConnector</key>
+						<integer>3</integer>
+						<key>port</key>
 						<data>
 						DwAAAA==
 						</data>
-						<key>UsbConnector</key>
-						<integer>3</integer>
 					</dict>
 					<key>SS04</key>
 					<dict>
@@ -203,17 +203,17 @@
 					</dict>
 					<key>SS06</key>
 					<dict>
-						<key>#port</key>
+						<key>UsbConnector</key>
+						<integer>3</integer>
+						<key>port</key>
 						<data>
 						EgAAAA==
 						</data>
-						<key>UsbConnector</key>
-						<integer>3</integer>
 					</dict>
 				</dict>
 			</dict>
 			<key>model</key>
-			<string>MacBookPro14,</string>
+			<string>MacBookPro14,1</string>
 		</dict>
 	</dict>
 	<key>OSBundleRequired</key>

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@
 - [x] iMessage, FaceTime, App Store, iTunes Store (with valid smbios)
 - [x] DRM support (iTunes Movies, Apple TV+, Amazon Prime and Netflix, and others)
 - [x] Sleep / Wake (lid sleep and lid wake) (works for me you can try for yourself)
+- [x] Internal camera (including Facetime)
+- [x] Bluetooth
 
 
 # What's not working? ⚠️
-- [x] Internal camera (including Facetime)
-- [x] Bluetooth (I will try to fix that)
+- [x] Airdrop and Handoff (not tested)


### PR DESCRIPTION
Enable USB-Ports used for webcam and bluetooth. With this change, bluetooth and webcam are working.

Airdrop and probably other Apple specific functionalities are not working.